### PR TITLE
chore: update default slice to 1

### DIFF
--- a/gateway.yml
+++ b/gateway.yml
@@ -259,7 +259,7 @@ pipeline:
     keep_running: true
     processor:
       - bulk_indexing:
-          num_of_slices: 3 #runtime slicing
+          num_of_slices: 1 #runtime slicing
           bulk:
             compress: false
             batch_size_in_mb: 10
@@ -287,7 +287,7 @@ pipeline:
     processor:
       - bulk_indexing:
           max_connection_per_node: 1000
-          num_of_slices: 2 #runtime slice
+          num_of_slices: 1 #runtime slice
           max_worker_size: 200
           idle_timeout_in_seconds: 10
           bulk:


### PR DESCRIPTION
This pull request includes changes to the `gateway.yml` file to adjust the configuration for the `bulk_indexing` processor. The most important changes involve reducing the number of slices used for runtime slicing.

Configuration adjustments:

* [`gateway.yml`](diffhunk://#diff-5d6d70a2833f4fe8754844376b0b16f77336430045c3128ddd9a424f523228e8L262-R262): Changed `num_of_slices` from 3 to 1 for the `bulk_indexing` processor to optimize runtime slicing.
* [`gateway.yml`](diffhunk://#diff-5d6d70a2833f4fe8754844376b0b16f77336430045c3128ddd9a424f523228e8L290-R290): Changed `num_of_slices` from 2 to 1 for the `bulk_indexing` processor to standardize the configuration.