### PR TITLE
docs: add v1.27.0 tag to release notes

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,16 @@ Information about release notes of INFINI Gateway is provided here.
 ## Latest (In development)
 
 ### Breaking changes
+
+### Features
+
+### Bug fix
+
+### Improvements
+
+## 1.27.0 (2024-12-13)
+
+### Breaking changes
 - chore: update default branch for vendor	
 ### Features
 - feat: auto issue certificates for domain


### PR DESCRIPTION
## What does this PR do
   add v1.27.0 tag to release notes
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation