### PR TITLE
docs: fixed input_queue field type: changed from int to string

### DIFF
--- a/docs/content.en/docs/references/processors/indexing_merge.md
+++ b/docs/content.en/docs/references/processors/indexing_merge.md
@@ -52,7 +52,7 @@ pipeline:
 
 | Name                    | Type   | Description                                                                                                                                                                                       |
 | ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| input_queue             | int    | Name of a subscribed queue                                                                                                                                                                        |
+| input_queue             | string | Name of a subscribed queue                                                                                                                                                                        |
 | worker_size             | int    | Number of threads that concurrently execute consumption tasks, which is set to `1` by default.                                                                                                    |
 | idle_timeout_in_seconds | int    | Timeout duration of the consumption queue, in seconds. The default value is `5`.                                                                                                                  |
 | bulk_size_in_kb         | int    | Size of a bulk request, in `KB`.                                                                                                                                                                  |

--- a/docs/content.en/docs/references/processors/json_indexing.md
+++ b/docs/content.en/docs/references/processors/json_indexing.md
@@ -33,7 +33,7 @@ pipeline:
 
 | Name                    | Type   | Description                                                                                                                                                                                       |
 | ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| input_queue             | int    | Name of a subscribed queue                                                                                                                                                                        |
+| input_queue             | string | Name of a subscribed queue                                                                                                                                                                        |
 | worker_size             | int    | Number of threads that concurrently execute consumption tasks, which is set to `1` by default.                                                                                                    |
 | idle_timeout_in_seconds | int    | Timeout duration of the consumption queue, in seconds. The default value is `5`.                                                                                                                  |
 | bulk_size_in_kb         | int    | Size of a bulk request, in `KB`.                                                                                                                                                                  |

--- a/docs/content.en/docs/references/processors/queue_consumer.md
+++ b/docs/content.en/docs/references/processors/queue_consumer.md
@@ -32,7 +32,7 @@ pipeline:
 
 | Name                    | Type   | Description                                                                                                                                                                               |
 | ----------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| input_queue             | int    | Name of a subscribed queue                                                                                                                                                                |
+| input_queue             | string | Name of a subscribed queue                                                                                                                                                                |
 | worker_size             | int    | Number of threads that concurrently execute consumption tasks, which is set to `1` by default.                                                                                            |
 | idle_timeout_in_seconds | int    | Timeout duration of the consumption queue, which is set to `1` by default.                                                                                                                |
 | elasticsearch           | string | Name of a target cluster, to which requests are saved.                                                                                                                                    |


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation