### PR TITLE
chore: remove unnecessary node re-selection on schema mismatch

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -16,6 +16,8 @@ Information about release notes of INFINI Gateway is provided here.
 ### Bug fix
 
 ### Improvements
+- Remove unnecessary node re-selection on schema mismatch for elasticsearch filter (#62)
+
 
 ## 1.28.0 (2025-01-11)
 


### PR DESCRIPTION
## What does this PR do

When Front and Upstream with different schema, the reverse proxy did a re-choose, this is not necessry.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation