### PR TITLE
docs: refactor document structure and add configs, metrics, node desc…

### DIFF
--- a/docs/content.en/docs/references/config.md
+++ b/docs/content.en/docs/references/config.md
@@ -135,7 +135,7 @@ configs:
 | configs.panic_on_config_error | bool | If there is an error in configuration loading, it will crash directly, default `true` |
 | configs.max_backup_files | int | The maximum number of configuration file backups, default `10`. |
 | configs.valid_config_extensions | []string | Valid configuration file suffixes, default `.tpl`, `.json`, `.yml`, `.yaml` |
-| configs.tls | object | TLS Configuration (Please refer to [TLS](#tls-配置)) |
+| configs.tls | object | TLS Configuration (Please refer to [TLS](#tls-configuration)) |
 | configs.always_register_after_restart | bool | Whether to register after the instance is restarted. When the instance runs in the K8S environment, this parameter needs to be enabled. |
 | configs.allow_generated_metrics_tasks | bool | Allow automatic generation of collection metrics tasks. |
 | configs.ignored_path | []string | Paths of configuration files that need to be ignored. |   

--- a/docs/content.en/docs/references/config.md
+++ b/docs/content.en/docs/references/config.md
@@ -67,7 +67,7 @@ PROD_ES_ENDPOINT=http://1.1.1.1:9200 LOGGING_ES_ENDPOINT=http://2.2.2.2:9201 ./b
 
 ## Path
 
-The instance configuration, data, and log directories.
+Common configuration for paths, including data, log and config directories.
 
 Example:
 
@@ -85,7 +85,7 @@ path.configs: "config"
 
 ## Log
 
-The configuration for instance logs.
+The configuration for logs.
 
 Example:
 
@@ -104,7 +104,7 @@ log:
 
 ## Configs
 
-Manage the configuration of instance.
+Manage the configuration.
 
 Example:
 
@@ -388,7 +388,7 @@ metrics:
 
 ## Node
 
-The configuration of instance node.
+The configuration of node.
 
 Example:
 


### PR DESCRIPTION
## What does this PR do
refactor document structure and add configs, metrics, node description

## Rationale for this change
This pull request includes significant updates to the configuration documentation in `docs/content.en/docs/references/config.md`. The changes primarily focus on reorganizing and expanding the configuration sections for better clarity and completeness.

Reorganization and expansion of configuration sections:

* Added a new "Path" section to describe instance configuration, data, and log directories with examples.
* Introduced a "Log" section to detail log configuration options, including log level, debug mode, and log format, with examples.
* Created a "Configs" section to manage instance configuration, including auto-reload, configuration management, and TLS settings, with examples.
* Added a "Metrics" section to describe system metrics collection configuration, including network, memory, disk, and CPU metrics, with examples.
* Introduced a "Node" section for instance node configuration, including IP patterns, labels, and tags, with examples.
## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation