### PR TITLE
docs: translate zh to en

### DIFF
--- a/docs/content.en/docs/references/processors/flow_replay.md
+++ b/docs/content.en/docs/references/processors/flow_replay.md
@@ -7,8 +7,7 @@ asciinema: false
 
 ## Description
 
-flow_replay 处理器用来异步消费队列里面的请求并使用异步用于在线请求的处理流程来进行消费处理。
-
+The flow_replay processor is used to asynchronously consume requests in the queue and use the asynchronous processing process for online requests to perform consumption processing.
 
 ## Configuration Example
 

--- a/docs/content.en/docs/references/processors/flow_replay.md
+++ b/docs/content.en/docs/references/processors/flow_replay.md
@@ -5,13 +5,14 @@ asciinema: false
 
 # flow_replay
 
-## 描述
+## Description
 
 flow_replay 处理器用来异步消费队列里面的请求并使用异步用于在线请求的处理流程来进行消费处理。
 
-## 配置示例
 
-一个简单的示例如下：
+## Configuration Example
+
+A simple example is as follows:
 
 ```
 pipeline:
@@ -37,10 +38,11 @@ pipeline:
                     commit_on_tag: "commit_message_allowed"
 ```
 
-## 参数说明
+## Parameter Description
 
-| 名称                    | 类型   | 说明                                                                                 |
+| Name                    | Type   | Description                                                                                 |
 | ----------------------- | ------ | ------------------------------------------------------------------------------------ |
-| message_field             | string    | 从队列获取到的消息，存放到上下文的字段名称, 默认 `messages`                          |
-| flow          | string | 以什么样的流程来消费队列里面的请求消息                                             |
-| commit_on_tag | string | 只有当前请求的上下文里面出现指定 tag 才会 commit 消息，默认为空表示执行完就 commit |
+| message_field             | string    | The context field name that store the message obtained from the queue, default `messages`.                          |
+| flow          | string | Specify the flow to consume request messages in the queue.                                             |
+| commit_on_tag | string | Only when the specified tag appears in the context of the current request will the message be committed. The default is empty, which means the commit will be executed once completed.
+ |


### PR DESCRIPTION
## What does this PR do

update references processors flow_replay en docs

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation