### PR TITLE
docs: fix link path

### DIFF
--- a/docs/content.zh/docs/references/processors/_index.md
+++ b/docs/content.zh/docs/references/processors/_index.md
@@ -58,7 +58,6 @@ pipeline:
 - [smtp](./smtp)
 - [merge_to_bulk](./merge_to_bulk)
 - [flow_replay](./flow_replay)
-- [replication_correlation](./replication_correlation)
 
 ### 索引写入
 


### PR DESCRIPTION
## What does this PR do

fix replication_correlation link in _index.md of processors

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation