### PR TITLE
fix: actions permissions and upgrade to 1.9.1

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,14 +16,16 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
-  # Read commit contents
+  # Only need to read contents
   contents: read
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78" # v1.7.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.1"
     with:
       # Example of specifying custom arguments
       scan-args: |-


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the GitHub Actions workflow file `.github/workflows/osv-scanner.yml` to improve security permissions and update the reusable workflow version.

Updates to GitHub Actions workflow:

* Added permissions to read actions, which is required to upload SARIF files to CodeQL.
* Updated the reusable workflow version from `v1.7.1` to `v1.9.1` to ensure the latest features and fixes are included.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation