### PR TITLE
chore: update release notes for v1.28.2

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -17,6 +17,10 @@ Information about release notes of INFINI Gateway is provided here.
 
 ### Improvements
 
+## 1.28.2 (2025-02-15)
+
+This release includes updates from the underlying [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/), which resolves several common issues and enhances overall stability and performance. While there are no direct changes to Gateway itself, the improvements inherited from Framework benefit Gateway indirectly.
+
 ## 1.28.1 (2025-01-24)
 
 ### Features

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -17,6 +17,10 @@ title: "版本历史"
 
 ### Improvements
 
+## 1.28.2 (2025-02-15)
+
+- 同步更新 [Framework v1.1.2](https://docs.infinilabs.com/framework/v1.1.2/docs/references/http_client/) 修复的一些已知问题
+
 ## 1.28.1 (2025-01-24)
 
 ### Features


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the release notes for the INFINI Gateway in both English and Chinese documentation. The primary change is the addition of information about the 1.28.2 release, which includes updates from the underlying Framework v1.1.2.

Updates to release notes:

* [`docs/content.en/docs/release-notes/_index.md`](diffhunk://#diff-6a5ab1b382c7b8d732e1667c4b8b236b020871d8f02badb577c84a938e5826f5R20-R23): Added release notes for version 1.28.2, highlighting updates from Framework v1.1.2 that improve stability and performance.
* [`docs/content.zh/docs/release-notes/_index.md`](diffhunk://#diff-4ff3d025818365a9a33f0fbd7fd1853b95162421d6d7d8067fce7fb0e3f9349fR20-R23): Added release notes for version 1.28.2 in Chinese, mentioning the synchronization of updates from Framework v1.1.2.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation