### PR TITLE
feat: add support for HTTP process compression

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,7 @@ Information about release notes of INFINI Gateway is provided here.
 ## Latest (In development)  
 ### Breaking changes  
 ### Features  
+- feat: support compress for http process (#90)
 ### Bug fix  
 ### Improvements  
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,7 +10,7 @@ Information about release notes of INFINI Gateway is provided here.
 ## Latest (In development)  
 ### Breaking changes  
 ### Features  
-- feat: support compress for http process (#90)
+- Add support for HTTP process compression (#90)
 ### Bug fix  
 ### Improvements  
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -10,6 +10,7 @@ title: "版本历史"
 ## Latest (In development)  
 ### Breaking changes  
 ### Features  
+- 支持`http`处理器压缩请求 (#90)
 ### Bug fix  
 ### Improvements  
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -10,7 +10,7 @@ title: "版本历史"
 ## Latest (In development)  
 ### Breaking changes  
 ### Features  
-- 支持`http`处理器压缩请求 (#90)
+- 实现 `HTTP` 处理器请求压缩支持 (#90)
 ### Bug fix  
 ### Improvements  
 

--- a/proxy/filters/elastic/bulk_request_mutate.go
+++ b/proxy/filters/elastic/bulk_request_mutate.go
@@ -25,6 +25,7 @@ package elastic
 
 import (
 	"fmt"
+	"src/github.com/savsgio/gotils/bytes"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -56,7 +57,7 @@ func (filter *ElasticsearchBulkRequestMutate) Name() string {
 }
 
 func (this *ElasticsearchBulkRequestMutate) Filter(ctx *fasthttp.RequestCtx) {
-
+	contentEncoding := string(ctx.Request.Header.PeekAny([]string{fasthttp.HeaderContentEncoding, fasthttp.HeaderContentEncoding2}))
 	pathStr := util.UnsafeBytesToString(ctx.PhantomURI().Path())
 
 	if util.SuffixStr(pathStr, "/_bulk") {
@@ -202,7 +203,15 @@ func (this *ElasticsearchBulkRequestMutate) Filter(ctx *fasthttp.RequestCtx) {
 			if !util.BytesHasSuffix(bulkBuff.B, elastic.NEWLINEBYTES) {
 				bulkBuff.Write(elastic.NEWLINEBYTES)
 			}
-			ctx.Request.SetRawBody(bulkBuff.Bytes())
+			if contentEncoding == "gzip" {
+				ctx.Request.ResetBody()
+				_, err := fasthttp.WriteGzipLevel(ctx.Request.BodyWriter(), bytes.Copy(bulkBuff.Bytes()), fasthttp.CompressBestCompression)
+				if err != nil {
+					panic(errors.Errorf("failed to compress message: %v", err))
+				}
+			} else {
+				ctx.Request.SetRawBody(bulkBuff.Bytes())
+			}
 		}
 	}
 

--- a/proxy/filters/elastic/bulk_request_mutate.go
+++ b/proxy/filters/elastic/bulk_request_mutate.go
@@ -25,7 +25,7 @@ package elastic
 
 import (
 	"fmt"
-	"src/github.com/savsgio/gotils/bytes"
+	"github.com/savsgio/gotils/bytes"
 	"time"
 
 	log "github.com/cihub/seelog"

--- a/proxy/filters/elastic/date_range_precision_tuning/date_range_precision_tuning.go
+++ b/proxy/filters/elastic/date_range_precision_tuning/date_range_precision_tuning.go
@@ -25,12 +25,12 @@ package date_range_precision_tuning
 
 import (
 	"fmt"
+	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/pipeline"
 	"infini.sh/framework/core/util"
 	"infini.sh/framework/lib/fasthttp"
-	log "src/github.com/cihub/seelog"
 )
 
 type DatePrecisionTuning struct {

--- a/proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go
+++ b/proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go
@@ -148,22 +148,22 @@ func (filter *RewriteToBulk) Filter(ctx *fasthttp.RequestCtx) {
 		//write final part
 		docBuf.WriteString("} }\n")
 
+		var body []byte
+		var err error
+
 		if action != "delete" {
 			if contentEncoding == "gzip" {
-				body, err := ctx.Request.BodyGunzip()
+				body, err = ctx.Request.BodyGunzip()
 				if err != nil {
 					panic(err)
 				}
-				util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
-				docBuf.Write(bytes.Copy(body))
-				docBuf.WriteString("\n")
 			} else {
-				body := ctx.Request.Body()
-				util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
-				docBuf.Write(bytes.Copy(body))
-				docBuf.WriteString("\n")
+				body = ctx.Request.Body()
 			}
 		}
+		util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
+		docBuf.Write(bytes.Copy(body))
+		docBuf.WriteString("\n")
 
 		if contentEncoding == "gzip" {
 			ctx.Request.ResetBody()

--- a/proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go
+++ b/proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/savsgio/gotils/bytes"
 	"infini.sh/framework/core/config"
+	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/pipeline"
 	"infini.sh/framework/core/util"
@@ -80,6 +81,7 @@ func (filter *RewriteToBulk) Filter(ctx *fasthttp.RequestCtx) {
 		pipeline := ctx.PhantomURI().QueryArgs().Peek("pipeline")
 		versionType := ctx.PhantomURI().QueryArgs().Peek("version_type")
 		version := ctx.PhantomURI().QueryArgs().Peek("version")
+		contentEncoding := string(ctx.Request.Header.PeekAny([]string{fasthttp.HeaderContentEncoding, fasthttp.HeaderContentEncoding2}))
 
 		action := "index"
 		if typePath == "_update" {
@@ -147,13 +149,31 @@ func (filter *RewriteToBulk) Filter(ctx *fasthttp.RequestCtx) {
 		docBuf.WriteString("} }\n")
 
 		if action != "delete" {
-			body := ctx.Request.Body()
-			util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
-			docBuf.Write(bytes.Copy(body))
-			docBuf.WriteString("\n")
+			if contentEncoding == "gzip" {
+				body, err := ctx.Request.BodyGunzip()
+				if err != nil {
+					panic(err)
+				}
+				util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
+				docBuf.Write(bytes.Copy(body))
+				docBuf.WriteString("\n")
+			} else {
+				body := ctx.Request.Body()
+				util.WalkBytesAndReplace(body, util.NEWLINE, util.SPACE)
+				docBuf.Write(bytes.Copy(body))
+				docBuf.WriteString("\n")
+			}
 		}
 
-		ctx.Request.SetBody(bytes.Copy(docBuf.Bytes()))
+		if contentEncoding == "gzip" {
+			ctx.Request.ResetBody()
+			_, err := fasthttp.WriteGzipLevel(ctx.Request.BodyWriter(), bytes.Copy(docBuf.Bytes()), fasthttp.CompressBestCompression)
+			if err != nil {
+				panic(errors.Errorf("failed to compress message: %v", err))
+			}
+		} else {
+			ctx.Request.SetBody(bytes.Copy(docBuf.Bytes()))
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the `proxy/filters/elastic` package to handle gzip content encoding in bulk request mutation and rewrite to bulk filters. The most important changes include adding gzip handling in the `Filter` methods and updating imports.

Enhancements to gzip handling:

* [`proxy/filters/elastic/bulk_request_mutate.go`](diffhunk://#diff-2f7c956fbd347330ac3c6fe71f0708c36804b4f601b1e0e382373ccf33f013a2L59-R60): Added logic to check for gzip content encoding and compress the request body if necessary in the `Filter` method. [[1]](diffhunk://#diff-2f7c956fbd347330ac3c6fe71f0708c36804b4f601b1e0e382373ccf33f013a2L59-R60) [[2]](diffhunk://#diff-2f7c956fbd347330ac3c6fe71f0708c36804b4f601b1e0e382373ccf33f013a2R206-R216)
* [`proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go`](diffhunk://#diff-339cd9f4b5da9c0893d0edfa2bcd198c1aa549b364adb9f9b82334c88e4ec235R84): Added logic to handle gzip content encoding, decompress the request body if necessary, and recompress it after processing in the `Filter` method. [[1]](diffhunk://#diff-339cd9f4b5da9c0893d0edfa2bcd198c1aa549b364adb9f9b82334c88e4ec235R84) [[2]](diffhunk://#diff-339cd9f4b5da9c0893d0edfa2bcd198c1aa549b364adb9f9b82334c88e4ec235R152-R178)

Import updates:

* [`proxy/filters/elastic/bulk_request_mutate.go`](diffhunk://#diff-2f7c956fbd347330ac3c6fe71f0708c36804b4f601b1e0e382373ccf33f013a2R28): Added import for `src/github.com/savsgio/gotils/bytes`.
* [`proxy/filters/elastic/rewrite_to_bulk/rewrite_to_bulk.go`](diffhunk://#diff-339cd9f4b5da9c0893d0edfa2bcd198c1aa549b364adb9f9b82334c88e4ec235R35): Added import for `infini.sh/framework/core/errors`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation