### PR TITLE
fix: HEAD request hangs in ES v8.x

### DIFF
--- a/proxy/output/elastic/reverseproxy.go
+++ b/proxy/output/elastic/reverseproxy.go
@@ -556,7 +556,10 @@ START:
 	}
 
 	metadata.CheckNodeTrafficThrottle(host, 1, myctx.Request.GetRequestLength(), 0)
-
+	method := string(myctx.Method())
+	if method == fasthttp.MethodHead {
+	        res.SkipBody = true
+	}
 	var err error
 	if p.proxyConfig.Timeout > 0 {
 		err = pc.DoTimeout(&myctx.Request, res, p.proxyConfig.Timeout)


### PR DESCRIPTION
fix: HEAD request hangs in ES v8.x

When utilizing a gateway with Elasticsearch 8.x, HEAD requests that receive responses with the Transfer-Encoding: chunked header may cause the gateway to hang during request processing.

curl -H 'Content-Type: application/json' -I http://127.0.0.1:8000/some_index_name