### PR TITLE
fix heartbeat  server conn when nil

### DIFF
--- a/service/heartbeat/server.go
+++ b/service/heartbeat/server.go
@@ -26,12 +26,13 @@ package heartbeat
 // golang achieve tcp long heartbeat connection with
 // server
 import (
-	log "github.com/cihub/seelog"
-	"infini.sh/framework/core/global"
 	"net"
 	"runtime"
 	"sync"
 	"time"
+
+	log "github.com/cihub/seelog"
+	"infini.sh/framework/core/global"
 )
 
 var (
@@ -115,7 +116,26 @@ func server(listen *net.TCPListener) {
 }
 
 func ServerHandler(conn net.Conn) {
-	defer conn.Close()
+	defer func() {
+		if !global.Env().IsDebug {
+			if r := recover(); r != nil {
+				var v string
+				switch r.(type) {
+				case error:
+					v = r.(error).Error()
+				case runtime.Error:
+					v = r.(runtime.Error).Error()
+				case string:
+					v = r.(string)
+				}
+				log.Error(v)
+			}
+		}
+
+		if conn != nil {
+			conn.Close()
+		}
+	}()
 	data := make([]byte, 128)
 	var uid string
 	var C *CS


### PR DESCRIPTION
## What does this PR do
fix  heartbeat  server conn close when nil
## Rationale for this change
floating_ip heartbeat server conn

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation