### PR TITLE
refactor: improve ReverseProxy locking and node discovery logic

### DIFF
--- a/proxy/output/elastic/reverseproxy.go
+++ b/proxy/output/elastic/reverseproxy.go
@@ -160,7 +160,7 @@ func (p *ReverseProxy) refreshNodes(force bool) {
 
 	ws := []int{}
 	esConfig := elastic.GetConfig(cfg.Elasticsearch)
-	if !esConfig.Discovery.Enabled {
+	if !esConfig.Discovery.Enabled && !force {
 		log.Trace("discovery is not enabled, skip nodes refresh")
 		return
 	}

--- a/proxy/output/elastic/reverseproxy.go
+++ b/proxy/output/elastic/reverseproxy.go
@@ -153,10 +153,6 @@ func isEndpointValid(node elastic.NodesInfo, cfg *ProxyConfig) bool {
 }
 
 func (p *ReverseProxy) refreshNodes(force bool) {
-
-	p.locker.Lock()
-	defer p.locker.Unlock()
-
 	if global.Env().IsDebug {
 		log.Trace("elasticsearch client nodes refreshing")
 	}
@@ -174,6 +170,9 @@ func (p *ReverseProxy) refreshNodes(force bool) {
 		log.Trace("metadata is nil and not forced, skip nodes refresh")
 		return
 	}
+
+	p.locker.Lock()
+	defer p.locker.Unlock()
 
 	hosts := []string{}
 	checkMetadata := false


### PR DESCRIPTION
## What does this PR do
This pull request makes minor refactoring and logic improvements to the `ReverseProxy` component in `proxy/output/elastic/reverseproxy.go`. The most notable changes are a reordering of import statements and a fix to the node refresh logic to ensure proper locking and correct handling of the discovery setting.

Improvements to node refresh logic:

* Moved the locking (`p.locker.Lock()`) in the `refreshNodes` method to occur after the early returns for discovery and metadata checks, ensuring that the lock is only acquired when necessary and avoiding unnecessary locking.
* Corrected the order of checks in `refreshNodes` so that the discovery-enabled and metadata checks occur before locking, which prevents unnecessary locking and improves efficiency.

Code organization:

* Reordered import statements for `hashset` and `errors` to follow Go conventions and maintain consistency.
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation