### PR TITLE
fix: track exact totals in scroll queries

### DIFF
--- a/common/scroll.go
+++ b/common/scroll.go
@@ -35,3 +35,19 @@ func GetScrollHitsTotal(version elastic.Version, data []byte) (int64, error) {
 	}
 	return jsonparser.GetInt(data, "hits", "total", "value")
 }
+
+func EnsureExactScrollTotalHits(version elastic.Version, query *elastic.SearchRequest) *elastic.SearchRequest {
+	if version.Distribution == elastic.Elasticsearch && version.Major < 7 {
+		return query
+	}
+
+	if query == nil {
+		query = &elastic.SearchRequest{}
+	}
+
+	if err := query.Set("track_total_hits", true); err != nil {
+		panic(err)
+	}
+
+	return query
+}

--- a/common/scroll_test.go
+++ b/common/scroll_test.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"infini.sh/framework/core/elastic"
+)
+
+func TestEnsureExactScrollTotalHits(t *testing.T) {
+	query := EnsureExactScrollTotalHits(elastic.Version{Distribution: elastic.Elasticsearch, Major: 7}, nil)
+	assert.NotNil(t, query)
+	assert.Contains(t, query.ToJSONString(), "\"track_total_hits\":true")
+}
+
+func TestEnsureExactScrollTotalHitsSkipLegacyElasticsearch(t *testing.T) {
+	query := EnsureExactScrollTotalHits(elastic.Version{Distribution: elastic.Elasticsearch, Major: 6}, nil)
+	assert.Nil(t, query)
+}

--- a/pipeline/dump_hash/dump_hash.go
+++ b/pipeline/dump_hash/dump_hash.go
@@ -191,6 +191,7 @@ func (processor *DumpHashProcessor) Process(c *pipeline.Context) error {
 			}()
 
 			var query *elastic.SearchRequest = elastic.GetSearchRequest(processor.config.QueryString, processor.config.QueryDSL, processor.config.Fields, processor.config.SortField, processor.config.SortType)
+			query = common.EnsureExactScrollTotalHits(processor.client.GetVersion(), query)
 			scrollResponse1, err := processor.client.NewScroll(processor.config.Indices, processor.config.ScrollTime, processor.config.BatchSize, query, tempSlice, processor.config.SliceSize)
 			if err != nil {
 				log.Errorf("%v-%v", processor.config.Output, err)

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -190,6 +190,7 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 			}()
 
 			var query *elastic.SearchRequest = elastic.GetSearchRequest(processor.config.QueryString, processor.config.QueryDSL, processor.config.Fields, processor.config.SortField, processor.config.SortType)
+			query = common.EnsureExactScrollTotalHits(processor.client.GetVersion(), query)
 			scrollResponse1, err := processor.client.NewScroll(processor.config.Indices, processor.config.ScrollTime, processor.config.BatchSize, query, tempSlice, processor.config.SliceSize)
 			if err != nil {
 				log.Errorf("%v-%v, query string: %v, query dsl: %v, search request: %s", processor.config.Output, err, processor.config.QueryString, processor.config.QueryDSL, util.MustToJSON(query))


### PR DESCRIPTION
## Summary
- set track_total_hits=true for non-legacy scroll searches
- reuse the helper in dump_hash and es_scroll before opening scrolls
- add coverage for modern and legacy Elasticsearch behavior

## Validation
- go test ./common ./pipeline/es_scroll ./pipeline/dump_hash
