### PR TITLE
chore: improve scroll processing and fix entry reload cleanup

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,7 +11,9 @@ Information about release notes of INFINI Gateway is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- Fix entry startup cleanup so failed reloads do not leave the listener port occupied.
 ### ✈️ Improvements  
+- Pre-initialize `es_scroll` output queues, reduce noisy routing logs, and unify duration/QPS logging for scroll and bulk processing paths.
 
 ## 1.30.2 (2026-03-16)
 ### ❌ Breaking changes  

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -11,7 +11,9 @@ title: "版本历史"
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- 修复入口启动失败时监听端口未释放的问题，避免 reload 失败后端口仍被占用。
 ### ✈️ Improvements  
+- 预初始化 `es_scroll` 输出队列，减少 `_routing` 相关噪音日志，并统一 scroll 与 bulk 处理路径的耗时/QPS 日志格式。
 
 ## 1.30.2 (2026-03-16)
 ### ❌ Breaking changes  

--- a/pipeline/dump_hash/dump_hash.go
+++ b/pipeline/dump_hash/dump_hash.go
@@ -327,6 +327,7 @@ func (processor *DumpHashProcessor) processingDocs(data []byte, outputQueueName 
 
 		hash := processor.Hash(processor.config.HashFunc, source)
 
+		// Match the source cluster's routing rules when partitioning migration data.
 		partitionID := elastic.GetShardID(processor.client.GetVersion().Major, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
 
 		buffer, ok := docs[partitionID]

--- a/pipeline/dump_hash/dump_hash.go
+++ b/pipeline/dump_hash/dump_hash.go
@@ -327,7 +327,7 @@ func (processor *DumpHashProcessor) processingDocs(data []byte, outputQueueName 
 
 		hash := processor.Hash(processor.config.HashFunc, source)
 
-		partitionID := elastic.GetShardID(7, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
+		partitionID := elastic.GetShardID(processor.client.GetVersion().Major, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
 
 		buffer, ok := docs[partitionID]
 		if !ok {

--- a/pipeline/dump_hash/dump_hash.go
+++ b/pipeline/dump_hash/dump_hash.go
@@ -29,7 +29,6 @@ package dump_hash
 
 import (
 	"fmt"
-	"math"
 	"path"
 	"runtime"
 	"strconv"
@@ -56,6 +55,7 @@ import (
 	"infini.sh/framework/lib/fasthttp"
 	es_common "infini.sh/framework/modules/elastic/common"
 	"infini.sh/gateway/common"
+	"infini.sh/gateway/pipeline/internal/logutil"
 )
 
 type DumpHashProcessor struct {
@@ -303,7 +303,7 @@ func (processor *DumpHashProcessor) Process(c *pipeline.Context) error {
 	wg.Wait()
 	progress.Stop()
 	duration := time.Since(start)
-	log.Infof("dump finished, es: %v, index: %v, docs: %v, duration: %vs, qps: %v ", processor.config.Elasticsearch, processor.config.Indices, totalDocsNeedToScroll, duration, math.Ceil(float64(totalDocsNeedToScroll)/math.Ceil((duration.Seconds()))))
+	log.Infof("dump finished, es: %v, index: %v, docs: %v, duration: %s, qps: %d", processor.config.Elasticsearch, processor.config.Indices, totalDocsNeedToScroll, logutil.FormatDuration(duration), logutil.QPS(totalDocsNeedToScroll, duration))
 
 	return nil
 }

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -65,9 +65,10 @@ import (
 )
 
 type ScrollProcessor struct {
-	config   Config
-	client   elastic.API
-	HTTPPool *fasthttp.RequestResponsePool
+	config       Config
+	client       elastic.API
+	HTTPPool     *fasthttp.RequestResponsePool
+	outputQueues []*queue.QueueConfig
 }
 
 type OutputQueueConfig struct {
@@ -139,6 +140,9 @@ func New(c *config.Config) (pipeline.Processor, error) {
 	if cfg.SliceSize < 1 {
 		cfg.SliceSize = 1
 	}
+	if cfg.PartitionSize < 1 {
+		cfg.PartitionSize = 1
+	}
 	if esVersion.Distribution == elastic.Elasticsearch && esVersion.Major < 5 {
 		cfg.SliceSize = 1
 	}
@@ -159,6 +163,7 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 
 	start := time.Now()
 	wg := sync.WaitGroup{}
+	processor.initOutputQueues()
 
 	var totalDocsNeedToScroll int64 = 0
 	var totalDocsScrolled int64 = 0
@@ -220,7 +225,7 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 			atomic.AddInt64(&totalDocsNeedToScroll, totalHits)
 			ctx.PutValue("es_scroll.total_hits", atomic.LoadInt64(&totalDocsNeedToScroll))
 
-			docSize := processor.processingDocs(scrollResponse1, processor.config.Output)
+			docSize := processor.processingDocs(scrollResponse1)
 			atomic.AddInt64(&totalDocsScrolled, int64(docSize))
 			ctx.PutValue("es_scroll.scrolled_docs", atomic.LoadInt64(&totalDocsScrolled))
 
@@ -280,7 +285,7 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 						panic(err)
 					}
 
-					docSize := processor.processingDocs(data, processor.config.Output)
+					docSize := processor.processingDocs(data)
 					atomic.AddInt64(&totalDocsScrolled, int64(docSize))
 					ctx.PutValue("es_scroll.scrolled_docs", atomic.LoadInt64(&totalDocsScrolled))
 
@@ -313,7 +318,27 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 	return nil
 }
 
-func (processor *ScrollProcessor) processingDocs(data []byte, outputQueueName string) int {
+func (processor *ScrollProcessor) initOutputQueues() {
+	if len(processor.outputQueues) == processor.config.PartitionSize {
+		return
+	}
+
+	outputQueues := make([]*queue.QueueConfig, processor.config.PartitionSize)
+	for partitionID := 0; partitionID < processor.config.PartitionSize; partitionID++ {
+		labels := map[string]interface{}{
+			"type": "scroll_docs",
+		}
+		if processor.config.Queue != nil {
+			for key, value := range processor.config.Queue.Labels {
+				labels[key] = value
+			}
+		}
+		outputQueues[partitionID] = queue.AdvancedGetOrInitConfig("", processor.config.Output+util.ToString(partitionID), labels)
+	}
+	processor.outputQueues = outputQueues
+}
+
+func (processor *ScrollProcessor) processingDocs(data []byte) int {
 
 	docSize := 0
 	var docs = map[int]*bytebufferpool.ByteBuffer{}
@@ -412,24 +437,13 @@ func (processor *ScrollProcessor) processingDocs(data []byte, outputQueueName st
 	}, "hits", "hits")
 
 	for k, v := range docs {
-		queueConfig := &queue.QueueConfig{}
-		queueConfig.Source = "dynamic"
-		queueConfig.Labels = util.MapStr{}
-		queueConfig.Labels["type"] = "scroll_docs"
-		if processor.config.Queue != nil {
-			for k, v := range processor.config.Queue.Labels {
-				queueConfig.Labels[k] = v
-			}
-		}
-		queueConfig.Name = outputQueueName + util.ToString(k)
-		queue.RegisterConfig(queueConfig)
-		pushQueue := queue.GetOrInitConfig(outputQueueName + util.ToString(k))
+		pushQueue := processor.outputQueues[k]
 		if global.Env().IsDebug {
 			log.Trace("queue config: ", pushQueue)
 		}
 
 		if err := queue.Push(pushQueue, v.Bytes()); err != nil {
-			log.Errorf("failed to push data to queue: %v, %v", outputQueueName+util.ToString(k), err)
+			log.Errorf("failed to push data to queue: %v, %v", processor.config.Output+util.ToString(k), err)
 			panic(err)
 		}
 
@@ -438,7 +452,7 @@ func (processor *ScrollProcessor) processingDocs(data []byte, outputQueueName st
 		bytebufferpool.Put("es_scroll", v)
 	}
 
-	stats.IncrementBy("scrolling_processing."+outputQueueName, "docs", int64(docSize))
+	stats.IncrementBy("scrolling_processing."+processor.config.Output, "docs", int64(docSize))
 
 	return docSize
 }

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -355,7 +355,7 @@ func (processor *ScrollProcessor) processingDocs(data []byte) int {
 		}
 
 		typeStr, err := jsonparser.GetString(value, "_type")
-		if err != nil {
+		if err != nil && !errors.Is(err, jsonparser.KeyPathNotFoundError) {
 			log.Debugf("get _type field error: %v", err)
 		}
 		routing, err := jsonparser.GetString(value, "_routing")

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -65,9 +65,9 @@ import (
 )
 
 type ScrollProcessor struct {
-	config       Config
-	client       elastic.API
-	HTTPPool     *fasthttp.RequestResponsePool
+	config   Config
+	client   elastic.API
+	HTTPPool *fasthttp.RequestResponsePool
 	// Cache partition queues so processingDocs stays on the hot path.
 	outputQueues []*queue.QueueConfig
 }

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -40,6 +40,7 @@ limitations under the License.
 package es_scroll
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -333,7 +334,7 @@ func (processor *ScrollProcessor) processingDocs(data []byte, outputQueueName st
 			log.Debugf("get _type field error: %v", err)
 		}
 		routing, err := jsonparser.GetString(value, "_routing")
-		if err != nil {
+		if err != nil && !errors.Is(err, jsonparser.KeyPathNotFoundError) {
 			log.Debugf("get _routing field error: %v", err)
 		}
 

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -41,7 +41,6 @@ package es_scroll
 
 import (
 	"fmt"
-	"math"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -61,6 +60,7 @@ import (
 	"infini.sh/framework/lib/fasthttp"
 	es_common "infini.sh/framework/modules/elastic/common"
 	"infini.sh/gateway/common"
+	"infini.sh/gateway/pipeline/internal/logutil"
 )
 
 type ScrollProcessor struct {
@@ -306,8 +306,8 @@ func (processor *ScrollProcessor) Process(c *pipeline.Context) error {
 	wg.Wait()
 	progress.Stop()
 
-	duration := time.Since(start).Seconds()
-	log.Infof("dump finished, es: %v, index: %v, docs: %v, duration: %vs, qps: %v ", processor.config.Elasticsearch, processor.config.Indices, totalDocsNeedToScroll, duration, math.Ceil(float64(totalDocsNeedToScroll)/math.Ceil((duration))))
+	duration := time.Since(start)
+	log.Infof("dump finished, es: %v, index: %v, docs: %v, duration: %s, qps: %d", processor.config.Elasticsearch, processor.config.Indices, totalDocsNeedToScroll, logutil.FormatDuration(duration), logutil.QPS(totalDocsNeedToScroll, duration))
 
 	return nil
 }

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -68,6 +68,7 @@ type ScrollProcessor struct {
 	config       Config
 	client       elastic.API
 	HTTPPool     *fasthttp.RequestResponsePool
+	// Cache partition queues so processingDocs stays on the hot path.
 	outputQueues []*queue.QueueConfig
 }
 
@@ -400,6 +401,7 @@ func (processor *ScrollProcessor) processingDocs(data []byte) int {
 
 		//hash := processor.Hash(processor.config.HashFunc, hashBuffer, source)
 
+		// Match the source cluster's routing rules when partitioning migration data.
 		partitionID := elastic.GetShardID(processor.client.GetVersion().Major, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
 
 		buffer, ok := docs[partitionID]

--- a/pipeline/es_scroll/es_scroll.go
+++ b/pipeline/es_scroll/es_scroll.go
@@ -400,7 +400,7 @@ func (processor *ScrollProcessor) processingDocs(data []byte) int {
 
 		//hash := processor.Hash(processor.config.HashFunc, hashBuffer, source)
 
-		partitionID := elastic.GetShardID(7, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
+		partitionID := elastic.GetShardID(processor.client.GetVersion().Major, util.UnsafeStringToBytes(id), processor.config.PartitionSize)
 
 		buffer, ok := docs[partitionID]
 		if !ok {

--- a/pipeline/fast_bulk_indexing/bulk_indexing.go
+++ b/pipeline/fast_bulk_indexing/bulk_indexing.go
@@ -43,6 +43,7 @@ import (
 	"infini.sh/framework/core/queue"
 	"infini.sh/framework/core/stats"
 	"infini.sh/framework/core/util"
+	"infini.sh/gateway/pipeline/internal/logutil"
 )
 
 //#操作合并任务
@@ -630,13 +631,14 @@ func (processor *BulkIndexingProcessor) submitBulkRequest(tag, esClusterID strin
 		defer cancel()
 
 		continueRequest, statsMap, _, err := bulkProcessor.Bulk(ctx, tag, meta, host, mainBuf)
+		duration := time.Since(start)
 		if global.Env().IsDebug {
-			stats.Timing("elasticsearch."+esClusterID+".bulk", "elapsed_ms", time.Since(start).Milliseconds())
+			stats.Timing("elasticsearch."+esClusterID+".bulk", "elapsed_ms", duration.Milliseconds())
 		}
 		if err != nil {
 			log.Errorf("submit bulk requests to elasticsearch [%v] failed, err:%v", meta.Config.Name, err)
 		}
-		log.Info(meta.Config.Name, ", ", host, ", stats: ", statsMap, ", count: ", count, ", size: ", util.ByteSize(uint64(size)), ", elapsed: ", time.Since(start), ", continue: ", continueRequest)
+		log.Info(meta.Config.Name, ", ", host, ", stats: ", statsMap, ", count: ", count, ", size: ", util.ByteSize(uint64(size)), ", elapsed: ", logutil.FormatDuration(duration), ", qps: ", logutil.QPS(int64(count), duration), ", continue: ", continueRequest)
 		return continueRequest, err
 	}
 

--- a/pipeline/internal/logutil/runtime.go
+++ b/pipeline/internal/logutil/runtime.go
@@ -1,0 +1,23 @@
+package logutil
+
+import (
+	"math"
+	"time"
+)
+
+func FormatDuration(duration time.Duration) string {
+	if duration <= 0 {
+		return "0s"
+	}
+	return duration.Round(time.Millisecond).String()
+}
+
+func QPS(total int64, duration time.Duration) int64 {
+	if total <= 0 {
+		return 0
+	}
+	if duration <= 0 {
+		return total
+	}
+	return int64(math.Ceil(float64(total) / duration.Seconds()))
+}

--- a/proxy/entry/entry.go
+++ b/proxy/entry/entry.go
@@ -93,20 +93,6 @@ func (this *Entrypoint) Start() error {
 		log.Trace("auto skip address ", this.listenAddress)
 	}
 
-	var ln net.Listener
-	var err error
-
-	if this.config.NetworkConfig.ReusePort && !strings.Contains(this.listenAddress, "::") {
-		log.Debug("reuse port ", this.listenAddress)
-		ln, err = reuseport.Listen("tcp4", this.config.NetworkConfig.GetBindingAddr())
-	} else {
-		ln, err = net.Listen("tcp", this.listenAddress)
-	}
-
-	if err != nil {
-		panic(errors.Errorf("error in listener(%v): %s", this.listenAddress, err))
-	}
-
 	this.router = r.New()
 
 	if this.config.RouterConfigName != "" {
@@ -256,6 +242,26 @@ func (this *Entrypoint) Start() error {
 		for _, ip := range this.routerConfig.IPAccessRules.ClientIP.PermittedList {
 			this.server.AddWhiteIPList(ip)
 		}
+	}
+
+	var ln net.Listener
+	var err error
+	started := false
+	defer func() {
+		if !started && ln != nil {
+			_ = ln.Close()
+		}
+	}()
+
+	if this.config.NetworkConfig.ReusePort && !strings.Contains(this.listenAddress, "::") {
+		log.Debug("reuse port ", this.listenAddress)
+		ln, err = reuseport.Listen("tcp4", this.config.NetworkConfig.GetBindingAddr())
+	} else {
+		ln, err = net.Listen("tcp", this.listenAddress)
+	}
+
+	if err != nil {
+		panic(errors.Errorf("error in listener(%v): %s", this.listenAddress, err))
 	}
 
 	if this.config.TLSConfig.TLSEnabled {
@@ -418,6 +424,7 @@ func (this *Entrypoint) Start() error {
 	})
 
 	log.Infof("entry [%s] listen at: %s%s", this.String(), this.GetSchema(), this.listenAddress)
+	started = true
 
 	return nil
 }

--- a/proxy/entry/entry.go
+++ b/proxy/entry/entry.go
@@ -248,6 +248,7 @@ func (this *Entrypoint) Start() error {
 	var err error
 	started := false
 	defer func() {
+		// Release the port if startup fails after binding during reload.
 		if !started && ln != nil {
 			_ = ln.Close()
 		}

--- a/proxy/entry/entry_test.go
+++ b/proxy/entry/entry_test.go
@@ -24,8 +24,10 @@
 package entry
 
 import (
+	"fmt"
 	config3 "infini.sh/framework/core/config"
 	"infini.sh/gateway/common"
+	"net"
 	"testing"
 )
 
@@ -48,4 +50,50 @@ func TestMulti(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func TestStartDoesNotHoldPortWhenFlowResolutionFails(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().(*net.TCPAddr)
+	_ = ln.Close()
+
+	routerName := "missing-flow-router"
+	common.RegisterRouterConfig(common.RouterConfig{
+		Name: routerName,
+		Rules: []common.RuleConfig{
+			{
+				Method:      []string{"GET"},
+				PathPattern: []string{"/"},
+				Flow:        []string{"missing-flow"},
+			},
+		},
+	})
+
+	entry := Entrypoint{
+		config: common.EntryConfig{
+			Enabled:          true,
+			Name:             "test-missing-flow",
+			RouterConfigName: routerName,
+			NetworkConfig: config3.NetworkConfig{
+				Binding: fmt.Sprintf("127.0.0.1:%d", addr.Port),
+			},
+		},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected start to panic when referenced flow is missing")
+		}
+
+		reuse, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", addr.Port))
+		if err != nil {
+			t.Fatalf("expected port to remain free after failed start: %v", err)
+		}
+		_ = reuse.Close()
+	}()
+
+	_ = entry.Start()
 }


### PR DESCRIPTION
## Summary
- fix entry startup cleanup so failed reloads do not leave the listener port occupied
- pre-initialize `es_scroll` output queues and reduce noisy routing debug output
- unify runtime logging for scroll and bulk paths with formatted duration and qps helpers
- ignore local Copilot helper files in `.gitignore`

## Testing
- `go test ./proxy/entry ./pipeline/dump_hash ./pipeline/es_scroll ./pipeline/fast_bulk_indexing`
