### PR TITLE
fix: gateway module ci builds for windows

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,6 +1,7 @@
 name: 'commit-message-check'
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   check-commit-message:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,15 +43,9 @@ jobs:
               shell: bash
               run: |
                 echo Home path is $HOME
-                export WORKBASE=$HOME/go/src/infini.sh
-                export WORK=$WORKBASE/$PNAME
-
-                # for format workspace
-                mkdir -p $HOME/go/src/
-                ln -s $GITHUB_WORKSPACE $WORKBASE
+                export WORK=$GITHUB_WORKSPACE/$PNAME
 
                 # check work folder
-                ls -lrt $WORKBASE/
                 ls -alrt $WORK
 
                 # for code format
@@ -63,8 +57,7 @@ jobs:
               id: check-changes
               shell: bash
               run: |
-                export WORKBASE=$HOME/go/src/infini.sh
-                export WORK=$WORKBASE/$PNAME
+                export WORK=$GITHUB_WORKSPACE/$PNAME
 
                 # for foramt check
                 cd $WORK
@@ -79,8 +72,7 @@ jobs:
             - name: Fail workflow if changes after format
               if: steps.check-changes.outputs.changes == 'true'
               run: |
-                export WORKBASE=$HOME/go/src/infini.sh
-                export WORK=$WORKBASE/$PNAME
+                export WORK=$GITHUB_WORKSPACE/$PNAME
 
                 # for foramt check
                 cd $WORK && echo
@@ -122,15 +114,9 @@ jobs:
                 GOFLAGS: -tags=ci
               run: |
                 echo Home path is $HOME
-                export WORKBASE=$HOME/go/src/infini.sh
-                export WORK=$WORKBASE/$PNAME
-
-                # for test workspace
-                mkdir -p $HOME/go/src/
-                ln -s $GITHUB_WORKSPACE $WORKBASE
+                export WORK=$GITHUB_WORKSPACE/$PNAME
 
                 # check work folder
-                ls -lrt $WORKBASE/
                 ls -alrt $WORK
 
                 # for unit test
@@ -170,15 +156,9 @@ jobs:
                 GOFLAGS: -tags=ci
               run: |
                 echo Home path is $HOME
-                export WORKBASE=$HOME/go/src/infini.sh
-                export WORK=$WORKBASE/$PNAME
-
-                # for lint workspace
-                mkdir -p $HOME/go/src/
-                ln -s $GITHUB_WORKSPACE $WORKBASE
+                export WORK=$GITHUB_WORKSPACE/$PNAME
 
                 # check work folder
-                ls -lrt $WORKBASE/
                 ls -alrt $WORK
 
                 # for code lint

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,7 +43,10 @@ jobs:
               shell: bash
               run: |
                 echo Home path is $HOME
+                export WORKBASE=$HOME/go/src/infini.sh
                 export WORK=$GITHUB_WORKSPACE/$PNAME
+                mkdir -p $WORKBASE
+                ln -sfn $GITHUB_WORKSPACE/framework $WORKBASE/framework
 
                 # check work folder
                 ls -alrt $WORK
@@ -57,7 +60,10 @@ jobs:
               id: check-changes
               shell: bash
               run: |
+                export WORKBASE=$HOME/go/src/infini.sh
                 export WORK=$GITHUB_WORKSPACE/$PNAME
+                mkdir -p $WORKBASE
+                ln -sfn $GITHUB_WORKSPACE/framework $WORKBASE/framework
 
                 # for foramt check
                 cd $WORK
@@ -72,7 +78,10 @@ jobs:
             - name: Fail workflow if changes after format
               if: steps.check-changes.outputs.changes == 'true'
               run: |
+                export WORKBASE=$HOME/go/src/infini.sh
                 export WORK=$GITHUB_WORKSPACE/$PNAME
+                mkdir -p $WORKBASE
+                ln -sfn $GITHUB_WORKSPACE/framework $WORKBASE/framework
 
                 # for foramt check
                 cd $WORK && echo
@@ -114,7 +123,10 @@ jobs:
                 GOFLAGS: -tags=ci
               run: |
                 echo Home path is $HOME
+                export WORKBASE=$HOME/go/src/infini.sh
                 export WORK=$GITHUB_WORKSPACE/$PNAME
+                mkdir -p $WORKBASE
+                ln -sfn $GITHUB_WORKSPACE/framework $WORKBASE/framework
 
                 # check work folder
                 ls -alrt $WORK
@@ -156,7 +168,10 @@ jobs:
                 GOFLAGS: -tags=ci
               run: |
                 echo Home path is $HOME
+                export WORKBASE=$HOME/go/src/infini.sh
                 export WORK=$GITHUB_WORKSPACE/$PNAME
+                mkdir -p $WORKBASE
+                ln -sfn $GITHUB_WORKSPACE/framework $WORKBASE/framework
 
                 # check work folder
                 ls -alrt $WORK

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Gateway is provided here.
 ### 🚀 Features  
 ### 🐛 Bug fix  
 - Fix entry startup cleanup so failed reloads do not leave the listener port occupied.
+- Fix PR checks to build Gateway in Go module mode without the legacy GOPATH vendor workspace dependency, and keep cross-platform builds working when `floating_ip` is enabled.
 ### ✈️ Improvements  
 - Pre-initialize `es_scroll` output queues, reduce noisy routing logs, and unify duration/QPS logging for scroll and bulk processing paths.
 

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ title: "版本历史"
 ### 🚀 Features  
 ### 🐛 Bug fix  
 - 修复入口启动失败时监听端口未释放的问题，避免 reload 失败后端口仍被占用。
+- 修复 PR 检查在 Go Modules 模式下对旧 GOPATH vendor 工作区的依赖，并保持启用 `floating_ip` 时跨平台构建可用。
 ### ✈️ Improvements  
 - 预初始化 `es_scroll` 输出队列，减少 `_routing` 相关噪音日志，并统一 scroll 与 bulk 处理路径的耗时/QPS 日志格式。
 

--- a/service/floating_ip/arp_supported.go
+++ b/service/floating_ip/arp_supported.go
@@ -1,0 +1,13 @@
+//go:build linux || darwin || freebsd || openbsd
+
+package floating_ip
+
+import (
+	"net"
+
+	"github.com/j-keck/arping"
+)
+
+func announceFloatingIP(ip net.IP, iface string) error {
+	return arping.GratuitousArpOverIfaceByName(ip, iface)
+}

--- a/service/floating_ip/arp_unsupported.go
+++ b/service/floating_ip/arp_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !(linux || darwin || freebsd || openbsd)
+
+package floating_ip
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+func announceFloatingIP(_ net.IP, _ string) error {
+	return fmt.Errorf("gratuitous arp announcement is not supported on %s", runtime.GOOS)
+}

--- a/service/floating_ip/floating_ip.go
+++ b/service/floating_ip/floating_ip.go
@@ -38,7 +38,6 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/j-keck/arping"
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/env"
 	"infini.sh/framework/core/errors"
@@ -214,7 +213,7 @@ func (module FloatingIPPlugin) SwitchToActiveMode() {
 
 				log.Trace("announce floating_ip, do arping every 10s")
 				ip := net1.ParseIP(floatingIPConfig.IP)
-				err := arping.GratuitousArpOverIfaceByName(ip, floatingIPConfig.Interface)
+				err := announceFloatingIP(ip, floatingIPConfig.Interface)
 				if err != nil {
 					if util.ContainStr(err.Error(), "unable to open") {
 						panic("please make sure running as root user, or sudo")


### PR DESCRIPTION
## Summary
- update PR checks to run from the checked-out workspace instead of the legacy GOPATH vendor layout
- keep `floating_ip` cross-platform builds compiling by routing gratuitous ARP through platform-specific helpers
- add release note entries for the CI/build fix and include the pull request commit-message workflow trigger update

## Testing
- GO111MODULE=on OFFLINE_BUILD=true make build-win-amd64

## CI error
[actions](https://github.com/infinilabs/ci/actions/runs/26473328730/job/77952312375)