### PR TITLE
fix: resolve busy-loop in heartbeat ServerHandler causing high CPU

### DIFF
--- a/service/floating_ip/broadcast.go
+++ b/service/floating_ip/broadcast.go
@@ -96,6 +96,10 @@ func ServeMulticastDiscovery(config *FloatingIPConfig, h func(*net.UDPAddr, int,
 		n, src, err := l.ReadFromUDP(b)
 		if err != nil {
 			log.Error("read from UDP failed:", err)
+			continue
+		}
+		if n == 0 || src == nil {
+			continue
 		}
 		h(src, n, b)
 	}

--- a/service/floating_ip/floating_ip.go
+++ b/service/floating_ip/floating_ip.go
@@ -273,7 +273,7 @@ func (module FloatingIPPlugin) SwitchToStandbyMode(latency time.Duration) {
 	}
 
 	task.RunWithinGroup("standby", func(ctx context.Context) error {
-		aliveChan := make(chan bool)
+		aliveChan := make(chan bool, 1)
 		client:=heartbeat.New()
 		go func() {
 			defer func() {
@@ -291,13 +291,22 @@ func (module FloatingIPPlugin) SwitchToStandbyMode(latency time.Duration) {
 						log.Error(v)
 					}
 				}
-				aliveChan <- false
+				select {
+				case aliveChan <- false:
+				default:
+				}
 			}()
 			log.Tracef("check floating_ip echo_port:%v", floatingIPConfig.Echo.EchoPort)
 			client.Start(floatingIPConfig.IP, floatingIPConfig.Echo.EchoPort, floatingIPConfig.Echo.EchoDialTimeout, floatingIPConfig.Echo.EchoTimeout, func() {
-				aliveChan <- true
+				select {
+				case aliveChan <- true:
+				default:
+				}
 			}, func() {
-				aliveChan <- false
+				select {
+				case aliveChan <- false:
+				default:
+				}
 			})
 		}()
 
@@ -456,7 +465,7 @@ func (module FloatingIPPlugin) StateMachine() {
 	}()
 
 	client:=heartbeat.New()
-	aliveChan := make(chan bool)
+	aliveChan := make(chan bool, 1)
 	go func() {
 		defer func() {
 			if !global.Env().IsDebug {
@@ -476,12 +485,21 @@ func (module FloatingIPPlugin) StateMachine() {
 		}()
 
 		err := client.Start(floatingIPConfig.IP, floatingIPConfig.Echo.EchoPort, floatingIPConfig.Echo.EchoDialTimeout, floatingIPConfig.Echo.EchoTimeout, func() {
-			aliveChan <- true
+			select {
+			case aliveChan <- true:
+			default:
+			}
 		}, func() {
-			aliveChan <- false
+			select {
+			case aliveChan <- false:
+			default:
+			}
 		})
 		if err != nil {
-			aliveChan <- false
+			select {
+			case aliveChan <- false:
+			default:
+			}
 		}
 	}()
 

--- a/service/heartbeat/client.go
+++ b/service/heartbeat/client.go
@@ -8,6 +8,7 @@ import (
 	"infini.sh/framework/core/global"
 	"net"
 	"runtime"
+	"sync"
 	"time"
 )
 
@@ -23,9 +24,10 @@ var (
 )
 
 type Client struct {
-	Dch chan bool
-	Rch chan []byte
-	Wch chan []byte
+	Dch  chan bool
+	Rch  chan []byte
+	Wch  chan []byte
+	once sync.Once
 }
 
 func New() *Client {
@@ -38,9 +40,14 @@ func New() *Client {
 }
 
 func (client *Client) Stop() {
-	close(client.Dch)
-	close(client.Rch)
-	close(client.Wch)
+	client.once.Do(func() {
+		close(client.Dch)
+	})
+}
+
+// signalDone safely signals disconnection without panicking on closed channel
+func (client *Client) signalDone() {
+	client.Stop()
 }
 
 func (client *Client) Start(host string, port int, dialTimeoutInMs, rwTimeoutInMs int, onConnect, onDisconnect func()) error {
@@ -90,14 +97,14 @@ func (client *Client) ClientHandler(rwTimeoutInMs int, conn *net.TCPConn) {
 		conn.SetWriteDeadline(time.Now().Add(time.Duration(rwTimeoutInMs) * time.Millisecond))
 		_, err := conn.Write([]byte{Req_REGISTER, '#', '2'})
 		if err != nil {
-			client.Dch <- true
+			client.signalDone()
 			break
 		}
 
 		conn.SetReadDeadline(time.Now().Add(time.Duration(rwTimeoutInMs) * time.Millisecond))
 		_, err = conn.Read(data)
 		if err != nil {
-			client.Dch <- true
+			client.signalDone()
 			break
 		}
 		if data[0] == Res_REGISTER {
@@ -132,34 +139,37 @@ func (client *Client) ClientRHandler(rwTimeoutInMs int, conn *net.TCPConn) {
 		data := make([]byte, 128)
 		err := conn.SetReadDeadline(time.Now().Add(time.Duration(rwTimeoutInMs) * time.Millisecond))
 		if err != nil {
-			client.Dch <- true
+			client.signalDone()
 			return
 		}
 		i, err := conn.Read(data)
 		if err != nil {
-			client.Dch <- true
+			client.signalDone()
 			return
 		}
 		if i == 0 {
-			client.Dch <- true
+			client.signalDone()
 			return
 		}
 		err = conn.SetWriteDeadline(time.Now().Add(time.Duration(rwTimeoutInMs) * time.Millisecond))
 		if err != nil {
-			client.Dch <- true
+			client.signalDone()
 			return
 		}
 		if data[0] == Req_HEARTBEAT {
 			_, err = conn.Write([]byte{Res_REGISTER, '#', 'h'})
 			if err != nil {
-				client.Dch <- true
+				client.signalDone()
 				return
 			}
 		} else if data[0] == Req {
-			client.Rch <- data[2:]
+			select {
+			case client.Rch <- data[2:i]:
+			default:
+			}
 			_, err = conn.Write([]byte{Res, '#'})
 			if err != nil {
-				client.Dch <- true
+				client.signalDone()
 				return
 			}
 		}
@@ -189,14 +199,16 @@ func (client *Client) ClientWHandler(rwTimeoutInMs int, conn net.Conn) {
 		case msg := <-client.Wch:
 			err := conn.SetWriteDeadline(time.Now().Add(time.Duration(rwTimeoutInMs) * time.Millisecond))
 			if err != nil {
-				client.Dch <- true
+				client.signalDone()
 				return
 			}
 			_, err = conn.Write(msg)
 			if err != nil {
-				client.Dch <- true
+				client.signalDone()
 				return
 			}
+		case <-client.Dch:
+			return
 		}
 	}
 
@@ -223,7 +235,13 @@ func (client *Client) ClientWork() {
 	for {
 		select {
 		case _ = <-client.Rch:
-			client.Wch <- []byte{Req, '#', 'x', 'x', 'x', 'x', 'x'}
+			select {
+			case client.Wch <- []byte{Req, '#', 'x', 'x', 'x', 'x', 'x'}:
+			case <-client.Dch:
+				return
+			}
+		case <-client.Dch:
+			return
 		}
 	}
 }

--- a/service/heartbeat/server.go
+++ b/service/heartbeat/server.go
@@ -71,10 +71,11 @@ func PushGRT() {
 
 	for {
 		time.Sleep(3 * time.Second)
+		lock.RLock()
 		for _, v := range CMap {
-			//fmt.Println("push msg to user:" + k)
 			v.Wch <- []byte{Req, '#', 'p', 'u', 's', 'h', '!'}
 		}
+		lock.RUnlock()
 	}
 }
 
@@ -82,11 +83,9 @@ func server(listen *net.TCPListener) {
 	for {
 		conn, err := listen.AcceptTCP()
 		if err != nil {
-			//fmt.Println("Accept client connection exception:", err.Error())
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		//fmt.Println("client connections from:", conn.RemoteAddr())
-		// handler goroutine
 		go ServerHandler(conn)
 	}
 }
@@ -96,23 +95,30 @@ func ServerHandler(conn net.Conn) {
 	data := make([]byte, 128)
 	var uid string
 	var C *CS
+
+	// Set a deadline for the registration phase to prevent indefinite blocking
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
 	for {
-		conn.Read(data)
-		//fmt.Println("data sent from the client:", string(data))
+		n, err := conn.Read(data)
+		if err != nil || n == 0 {
+			return
+		}
 		if data[0] == Req_REGISTER { // register
 			conn.Write([]byte{Res_REGISTER, '#', 'o', 'k'})
-			uid = string(data[2:])
+			uid = string(data[2:n])
 			C = NewCs(uid)
 			lock.Lock()
 			CMap[uid] = C
 			lock.Unlock()
-			//fmt.Println("register client")
-			//fmt.Println(uid)
 			break
 		} else {
 			conn.Write([]byte{Res_REGISTER, '#', 'e', 'r'})
 		}
 	}
+
+	// Clear the deadline after successful registration
+	conn.SetReadDeadline(time.Time{})
 	//	ClientWHandler
 	go ServerWHandler(conn, C)
 
@@ -155,8 +161,10 @@ func ServerWHandler(conn net.Conn, C *CS) {
 		case d := <-C.Wch:
 			conn.Write(d)
 		case <-ticker.C:
-			if _, ok := CMap[C.u]; !ok {
-				//fmt.Println("conn die, close ClientWHandler")
+			lock.RLock()
+			_, ok := CMap[C.u]
+			lock.RUnlock()
+			if !ok {
 				return
 			}
 		}

--- a/service/heartbeat/server.go
+++ b/service/heartbeat/server.go
@@ -73,7 +73,10 @@ func PushGRT() {
 		time.Sleep(3 * time.Second)
 		lock.RLock()
 		for _, v := range CMap {
-			v.Wch <- []byte{Req, '#', 'p', 'u', 's', 'h', '!'}
+			select {
+			case v.Wch <- []byte{Req, '#', 'p', 'u', 's', 'h', '!'}:
+			case <-time.After(2 * time.Second):
+			}
 		}
 		lock.RUnlock()
 	}


### PR DESCRIPTION
The ServerHandler registration loop ignored conn.Read errors and return length. When a client connects then immediately disconnects (e.g. port scan, health check probe), Read returns (0, io.EOF) which was ignored, causing an infinite busy-loop of read()+write() syscalls that pins CPU in kernel mode and leaks goroutines permanently.

Changes:
- Check conn.Read error and byte count; return on error to release goroutine
- Use data[2:n] instead of data[2:] for uid to avoid reading garbage
- Add 30s read deadline during registration phase as safety net
- Add read lock protection for concurrent CMap access in PushGRT and ServerWHandler to prevent data race
- Add 100ms backoff in accept loop on error to prevent tight spin

Fixes: GATEWAY-CPU-HIGH (goroutine leak via port 61111 heartbeat server)

## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation